### PR TITLE
Add test case for naf.dump and hopefully fix it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ nosetests.xml
 *~
 \#*\#
 .\#*
+
+env
+env3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - pip install -q -e . 
 
 script:
- - nosetests
+ - nosetests -s
  

--- a/KafNafParserPy/KafNafParserMod.py
+++ b/KafNafParserPy/KafNafParserMod.py
@@ -25,6 +25,7 @@ __version__ = '1.3.1'
 __author__ = 'Ruben Izquierdo Bevia'
 
 import io
+import sys
 
 from lxml import etree
 
@@ -621,7 +622,8 @@ class KafNafParser:
         if filename is None:
             with io.BytesIO() as buffer:
                 self.dump(filename=buffer)
-                print(buffer.getvalue().decode("UTF-8"))
+                bytes = buffer.getvalue()
+                getattr(sys.stdout, 'buffer', sys.stdout).write(bytes)
         else:
             self.tree.write(filename,encoding='UTF-8',pretty_print=True,xml_declaration=True)
 

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals, print_function
+
+import sys
+import os
+import tempfile
+from io import BytesIO
+from contextlib import contextmanager
+
+from nose.tools import assert_in
+
+from KafNafParserPy import KafNafParser
+
+@contextmanager
+def capture_stdout(dest=None):
+    """Capture stdout into dest"""
+    if dest is None: dest = BytesIO()
+    saved_stdout = sys.stdout
+    sys.stdout = dest
+    try:
+        yield dest
+    finally:
+        sys.stdout = saved_stdout
+        
+def test_dump():
+    """
+    Can we use naf.dump() to stdout and file?
+
+    Make sure the run with nosetests -s, otherwise python3 will err
+    """
+
+    naf = KafNafParser(type="NAF")
+    token = naf.create_wf("\xd8lleg\xe5rd", 1, 1)
+    expected = '<![CDATA[\xd8lleg\xe5rd]]></wf>'
+
+    # do we get an error on dumping to stdout without redirect?
+    naf.dump()
+    
+    # Can we dump to stdout?
+    with capture_stdout() as s:
+        naf.dump()
+    output = s.getvalue().decode("utf-8")
+    assert_in(expected, output)
+    
+    # Can we dump to a named file?
+    f = tempfile.NamedTemporaryFile(suffix=".xml", delete=False)
+    try:
+        naf.dump(f.name)
+        f.close()
+        output = open(f.name, mode='rb').read().decode('utf-8')
+    finally:
+        os.remove(f.name)
+    assert_in(expected, output)
+        
+if __name__=='__main__':
+    test_dump()


### PR DESCRIPTION
I remember the problem, and I think I understand Paul's problem. 

The real problem is that it is really difficult to write python2+3 code that prints utf-8 to stdout. @martijnbastiaan proposed the original solution by `print`ing the unicode object, since python 3 assumes a utf-8 encoding by default and python2 also encodes to utf-8 if you run it in a terminal. However, that fails on python2 if you redirect stdout to e.g. a file, since it then assumes ascii encoding. This is probably @PaulHuygen's problem?

The "solution" is an ugly hack to write the utf-8 to sys.stdout on python2 or sys.stdout.buffer on python3, which can be one-lined with a getattr call. 

This still fails in regular nosetests since they redirect stdout, but with nosetest -s it does work. 

I've added unit tests for dumping to file, to redirected stdout, and to normal stdout (only checking if there are no errors). 
