### PR TITLE
Add `__iter__` to `Ccoreferences`

### DIFF
--- a/KafNafParserPy/coreference_data.py
+++ b/KafNafParserPy/coreference_data.py
@@ -181,7 +181,15 @@ class Ccoreferences:
         """
         for coref_node in self.__get_corefs_nodes():
             yield Ccoreference(coref_node,self.type)
-            
+
+    def __iter__(self):
+        """
+        Iterator that returns all the coreference objects
+        @rtype: L{Ccoreference}
+        @return: list of coreference objects (iterator)
+        """
+        return self.get_corefs()
+
     def to_kaf(self):
         """
         Converts the coreference layer to KAF


### PR DESCRIPTION
Similar to Cterms:

https://github.com/cltl/KafNafParserPy/blob/cdf7ab6d41f07423b9ca53eb4ee221c0f6335f66/KafNafParserPy/term_data.py#L318