### PR TITLE
Started adding type hints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
+  - "3.5"
+  - "3.6"
   
 install:
   - pip install -q -e . 

--- a/KafNafParserPy/KafNafParserMod.py
+++ b/KafNafParserPy/KafNafParserMod.py
@@ -26,6 +26,7 @@ __author__ = 'Ruben Izquierdo Bevia'
 
 import io
 import sys
+from typing import Iterable, List
 
 from lxml import etree
 
@@ -508,7 +509,7 @@ class KafNafParser:
         return self.lang
 
 
-    def get_tokens(self):
+    def get_tokens(self) -> Iterable[Cwf]:
         """Iterator that returns all the tokens from the text layer
         @rtype: L{Cwf}
         @return: list of token objects
@@ -516,7 +517,7 @@ class KafNafParser:
         for token in self.text_layer:
             yield token
 
-    def get_terms(self):
+    def get_terms(self) -> Iterable[Cterm]:
         """Iterator that returns all the terms from the term layer
         @rtype: L{Cterm}
         @return: list of term objects
@@ -526,7 +527,7 @@ class KafNafParser:
                 yield term
 
 
-    def get_coreferences(self):
+    def get_coreferences(self) -> Iterable[Ccoreference]:
         """Iterator that returns all the terms from the term layer
         @rtype: L{Ccoreference}
         @return: list of term objects
@@ -577,7 +578,7 @@ class KafNafParser:
         else:
             return None
 
-    def get_token(self,token_id):
+    def get_token(self, token_id: str) -> Cwf:
         """
         Returns a token object for the specified token_id
         @type token_id:string
@@ -591,7 +592,7 @@ class KafNafParser:
             return None
 
 
-    def get_term(self,term_id):
+    def get_term(self, term_id: str) -> Cterm:
         """
         Returns a term object for the specified term_id
         @type term_id:string
@@ -1341,7 +1342,7 @@ class KafNafParser:
 
     ## EXTRA FUNCTIONS
     ## Gets the token identifiers in the span of a term id
-    def get_dict_tokens_for_termid(self, term_id):
+    def get_dict_tokens_for_termid(self, term_id: str) -> List[str]:
         """
         Returns the tokens ids that are the span of the term specified
         @type term_id: string
@@ -1357,7 +1358,7 @@ class KafNafParser:
         return self.dict_tokens_for_tid.get(term_id,[])
 
     ## Maps a list of token ids to term ids
-    def map_tokens_to_terms(self,list_tokens):
+    def map_tokens_to_terms(self, list_tokens: Iterable[str]) -> List[str]:
         """
         Maps a list of token ids to the corresponding term ids
         @type list_tokens: list

--- a/KafNafParserPy/KafNafParserMod.py
+++ b/KafNafParserPy/KafNafParserMod.py
@@ -545,7 +545,7 @@ class KafNafParser:
             for markable in self.markable_layer:
                 yield markable
 
-    def get_chunks(self):
+    def get_chunks(self) -> Iterable[Cchunk]:
         """Iterator that returns all the chunks from the chunk layer
         @rtype: L{Cchunk}
         @return: list of chunk objects
@@ -555,7 +555,7 @@ class KafNafParser:
                 yield chunk
 
 
-    def get_statements(self):
+    def get_statements(self) -> Iterable[Cstatement]:
         """Iterator that returns all the statements from the attribution layer
         @rtype: L{Cstatement}
         @return: list of statement objects
@@ -565,7 +565,7 @@ class KafNafParser:
                 yield statement
 
 
-    def get_markable(self,markable_id):
+    def get_markable(self, markable_id: str) -> Cmarkable:
         """
         Returns a markable object for the specified markable_id
         @type markable_id:string
@@ -606,7 +606,7 @@ class KafNafParser:
             return None
 
 
-    def get_chunk(self,chunk_id):
+    def get_chunk(self, chunk_id: str) -> Cchunk:
         """
         Returns a chunk object for the specified chunk_id
         @type chunk_id:string
@@ -619,7 +619,7 @@ class KafNafParser:
         else:
             return None
 
-    def get_properties(self):
+    def get_properties(self) -> Cproperty:
         """
         Returns all the properties of the features layer (iterator)
         @rtype: L{Cproperty}
@@ -629,7 +629,7 @@ class KafNafParser:
             for property in self.features_layer.get_properties():
                 yield propertyfound_entities.get(mention.string)
 
-    def get_entities(self):
+    def get_entities(self) -> Iterable[Centity]:
         """
         Returns a list of all the entities in the object
         @rtype: L{Centity}
@@ -640,7 +640,7 @@ class KafNafParser:
                 yield entity
 
 
-    def get_entity(self,entity_id):
+    def get_entity(self, entity_id: str) -> Centity:
         """
         Returns an entity object for the specified entity_id
         @type entity_id:string
@@ -654,7 +654,7 @@ class KafNafParser:
             return None
 
 
-    def get_opinions(self):
+    def get_opinions(self) -> Iterable[Copinion]:
         """
         Returns a list of all the opinions in the object
         @rtype: L{Copinion}
@@ -664,7 +664,7 @@ class KafNafParser:
             for opinion in self.opinion_layer.get_opinions():
                 yield opinion
 
-    def get_predicates(self):
+    def get_predicates(self) -> Iterable[Cpredicate]:
         """
         Returns a list of all the predicates in the object
         @rtype: L{Cpredicate}
@@ -674,7 +674,7 @@ class KafNafParser:
             for pred in self.srl_layer.get_predicates():
                 yield pred
 
-    def get_raw(self):
+    def get_raw(self) -> str:
         """
         Returns the raw text as a string
         @rtype: string
@@ -683,7 +683,7 @@ class KafNafParser:
         if self.raw is not None:
             return self.raw
 
-    def set_raw(self,text):
+    def set_raw(self, text: str):
         """
         Sets the text of the raw element (or creates the layer if does not exist)
         @param text: text of the raw layer
@@ -695,7 +695,7 @@ class KafNafParser:
             self.root.insert(0,node_raw)
         node_raw.text = etree.CDATA(text)
 
-    def get_timeExpressions(self):
+    def get_timeExpressions(self) -> Iterable[Ctime]:
         """
         Returns a list of all the timeexpressions in the text
         @rtype: L{Ctime}

--- a/KafNafParserPy/entity_data.py
+++ b/KafNafParserPy/entity_data.py
@@ -3,6 +3,8 @@ Parser for the entity layer in KAF/NAF
 """
 
 # Modified for KAF NAF adaptation
+from typing import Iterable
+
 from lxml import etree
 from lxml.objectify import dump
 import re
@@ -30,7 +32,7 @@ class Centity:
         else:
             self.node = node
 
-    def set_comment(self,c):
+    def set_comment(self, c: str):
         """
         Sets the comment for the element
         @type c: string
@@ -59,7 +61,7 @@ class Centity:
         elif self.type == 'KAF':
             return self.node.get('eid')
 
-    def set_id(self,i):
+    def set_id(self, i: str):
         """
         Sets the identifier for the entity
         @type i: string
@@ -70,7 +72,7 @@ class Centity:
         elif self.type == 'KAF':
             self.node.set('eid',i)
                 
-    def get_type(self):
+    def get_type(self) -> str:
         """
         Returns the type of the entity
         @rtype: string
@@ -78,7 +80,7 @@ class Centity:
         """
         return self.node.get('type')
     
-    def set_type(self,t):
+    def set_type(self, t: str):
         """
         Sets the type for the entity
         @type t: string
@@ -86,7 +88,7 @@ class Centity:
         """
         self.node.set('type',t)
         
-    def get_references(self):
+    def get_references(self) -> Iterable[Creferences]:
         """
         Returns the references of the entity
         @rtype: L{Creferences}
@@ -95,7 +97,7 @@ class Centity:
         for ref_node in self.node.findall('references'):
             yield Creferences(ref_node)
 
-    def add_reference(self,ref):
+    def add_reference(self, ref: Creferences):
         """
         Adds a reference to the layer
         @type ref: L{Creferences}
@@ -103,7 +105,7 @@ class Centity:
         """
         self.node.append(ref.get_node())
                     
-    def add_external_reference(self,ext_ref):
+    def add_external_reference(self, ext_ref: CexternalReferences):
         """
         Adds an external reference to the entity
         @param ext_ref: the external reference object
@@ -121,7 +123,7 @@ class Centity:
         ext_refs.add_external_reference(ext_ref)  
         
         
-    def get_external_references(self):
+    def get_external_references(self) -> Iterable[CexternalReferences]:
         """
         Returns the external references of the element
         @rtype: L{CexternalReference}
@@ -133,7 +135,7 @@ class Centity:
             for ext_ref in ext_refs:
                 yield ext_ref    
     
-    def get_source(self):
+    def get_source(self) -> str:
         """
         Returns the source of the entity
         @rtype: string
@@ -141,7 +143,7 @@ class Centity:
         """
         return self.node.get('source')
     
-    def set_source(self,s):
+    def set_source(self, s: str):
         """
         Sets the source for the entity
         @type s: string

--- a/KafNafParserPy/references_data.py
+++ b/KafNafParserPy/references_data.py
@@ -2,6 +2,8 @@
 Parser for the references objects in KAF/NAF
 """
 # Modified for NAF/KAf
+from typing import Iterable, Iterator
+
 from lxml import etree
 
 from .span_data import Cspan
@@ -11,7 +13,7 @@ class Creferences:
     """
     This class encapsulates the references objects in KAF/NAF
     """
-    def __init__(self,node=None):
+    def __init__(self, node=None):
         """
         Constructor of the object
         @type node: xml Element or None (to create and empty one)
@@ -31,7 +33,7 @@ class Creferences:
         """
         return self.node
     
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Cspan]:
         """
         Iterator that returns all the span objects in the reference
         @rtype: L{Cspan}
@@ -40,7 +42,7 @@ class Creferences:
         for span_node in self.node.findall('span'):
             yield Cspan(span_node)
             
-    def add_span(self,term_span):
+    def add_span(self, term_span: Iterable[str]):
         """
         Adds a list of term ids a new span in the references
         @type term_span: list
@@ -50,7 +52,7 @@ class Creferences:
         new_span.create_from_ids(term_span)
         self.node.append(new_span.get_node())
 
-    def get_span(self):
+    def get_span(self) -> Cspan:
         """
         Returns the span object of the reference
         @rtype: L{Cspan}
@@ -62,7 +64,7 @@ class Creferences:
         else:
             return None
     
-    def set_span(self,this_span):
+    def set_span(self,this_span: Cspan):
         """
         Sets the span for the lemma
         @type this_span: L{Cspan}

--- a/KafNafParserPy/span_data.py
+++ b/KafNafParserPy/span_data.py
@@ -3,6 +3,7 @@ Parser for the span element
 """
 
 # Modified for KAF/NAF
+from typing import Iterator, Iterable, List
 
 from lxml import etree
 from lxml.objectify import dump
@@ -24,7 +25,7 @@ class Ctarget:
         else:
             self.node = node
             
-    def get_id(self):
+    def get_id(self) -> str:
         """
         Returns the id of the element
         @rtype: string
@@ -32,7 +33,7 @@ class Ctarget:
         """
         return self.node.get('id')
     
-    def set_id(self,this_id):
+    def set_id(self, this_id: str):
         """
         Set the id of the element
         @type this_id: string
@@ -40,7 +41,7 @@ class Ctarget:
         """
         self.node.set('id',this_id)
     
-    def set_head(self,head):
+    def set_head(self, head: str):
         """
         Sets value of head
         @type head: string
@@ -48,7 +49,7 @@ class Ctarget:
         """
         self.node.set('head',head)
 
-    def get_head(self):
+    def get_head(self) -> str:
         """
         Returns the head of the element
         @rtype: string
@@ -62,7 +63,7 @@ class Ctarget:
         """
         self.node.set('head','yes')
         
-    def is_head(self):
+    def is_head(self) -> bool:
         """
         Returns whether this target is set as head or not
         @rtype: boolean
@@ -84,7 +85,7 @@ class Cspan:
     """
     This class encapsulates a span object in KAF/NAF
     """
-    def __init__(self,node=None):
+    def __init__(self, node=None):
         """
         Constructor of the object
         @type node: xml Element or None (to create and empty one)
@@ -109,7 +110,7 @@ class Cspan:
                 break
         return id_head
              
-    def add_target_id(self,this_id):
+    def add_target_id(self, this_id: str):
         """
         Adds a new target to the span with the specified id
         @type this_id: string
@@ -119,7 +120,7 @@ class Cspan:
         new_target.set_id(this_id)
         self.node.append(new_target.get_node())
              
-    def create_from_ids(self,list_ids):
+    def create_from_ids(self, list_ids: Iterable[str]):
         """
         Adds new targets to the span with the specified ids
         @type list_ids: list
@@ -130,7 +131,7 @@ class Cspan:
             new_target.set_id(this_id)
             self.node.append(new_target.get_node())
 
-    def create_from_targets(self,list_targs):
+    def create_from_targets(self, list_targs: Iterable[Ctarget]):
         """
         Adds new targets to the span that are defined in a list
         @type list_targs: list
@@ -138,23 +139,20 @@ class Cspan:
         """
         for this_target in list_targs:
             self.node.append(this_target.get_node())
-    
 
-    def add_target(self,target):
+    def add_target(self, target: Ctarget):
         """
         Adds a target object to the span
         @type target: L{Ctarget}
         @param target: target object
         """
         self.node.append(target.get_node())
-                   
-
 
     def __get_target_nodes(self):
         for target_node in self.node.findall('target'):
             yield target_node
     
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Ctarget]:
         """
         Iterator taht returns the target objects
         @rtype: L{Ctarget}
@@ -163,7 +161,7 @@ class Cspan:
         for target_node in self.__get_target_nodes():
             yield Ctarget(target_node)
             
-    def get_span_ids(self):
+    def get_span_ids(self) -> List[str]:
         """
         Returns the list of target ids for the span
         @rtype: list

--- a/KafNafParserPy/term_data.py
+++ b/KafNafParserPy/term_data.py
@@ -36,7 +36,7 @@ class Cterm:
         """
         return self.node
             
-    def get_id(self):
+    def get_id(self) -> str:
         """
         Returns the term identifier
         @rtype: string
@@ -47,7 +47,7 @@ class Cterm:
         elif self.type == 'KAF':
             return self.node.get('tid')
     
-    def set_id(self,i):
+    def set_id(self, i: str):
         """
         Sets the identifier for the term
         @type i: string
@@ -58,7 +58,7 @@ class Cterm:
         elif self.type == 'KAF':
             self.node.set('tid',i)
                     
-    def get_lemma(self):
+    def get_lemma(self) -> str:
         """
         Returns the lemma of the object
         @rtype: string
@@ -66,7 +66,7 @@ class Cterm:
         """
         return self.node.get('lemma')
     
-    def set_lemma(self,l):
+    def set_lemma(self, l: str):
         """
         Sets the lemma for the term
         @type l: string

--- a/KafNafParserPy/text_data.py
+++ b/KafNafParserPy/text_data.py
@@ -31,7 +31,7 @@ class Cwf:
         """
         return self.node
     
-    def set_id(self,this_id):
+    def set_id(self, this_id: str):
         """
         Set the identifier for the token
         @type this_id: string
@@ -42,7 +42,7 @@ class Cwf:
         elif self.type == 'KAF':
             return self.node.set('wid',this_id)
                 
-    def get_id(self):
+    def get_id(self) -> str:
         """
         Returns the token identifier
         @rtype: string
@@ -53,7 +53,7 @@ class Cwf:
         elif self.type == 'KAF':
             return self.node.get('wid')
     
-    def set_text(self,this_text):
+    def set_text(self, this_text: str):
         """
         Set the text for the token
         @type this_text: string
@@ -61,7 +61,7 @@ class Cwf:
         """
         self.node.text = etree.CDATA(this_text)
         
-    def get_text(self):
+    def get_text(self) -> str:
         """
         Returns the text of the token
         @rtype: string
@@ -69,15 +69,15 @@ class Cwf:
         """
         return self.node.text
     
-    def set_sent(self,this_sent):
+    def set_sent(self, this_sent: str):
         """
         Set the sentence for the token
         @type this_sent: string
         @param this_sent: the sentence identifier
         """
-        self.node.set('sent',this_sent)
+        self.node.set('sent', this_sent)
         
-    def get_sent(self):
+    def get_sent(self) -> str:
         """
         Returns the sentence of the token
         @rtype: string
@@ -85,7 +85,7 @@ class Cwf:
         """
         return self.node.get('sent')
     
-    def get_offset(self):
+    def get_offset(self) -> str:
         """
         Returns the offset of the token
         @rtype: string
@@ -94,7 +94,7 @@ class Cwf:
         return self.node.get('offset')
     
 
-    def set_offset(self,offset):
+    def set_offset(self, offset: str):
         """
         Set the offset for the token
         @type offset: string


### PR DESCRIPTION
I started adding some type hints where it was useful for me (mostly term and token layers) to make it easier to work with the library

(edit: automated unit tests ~fail because they are set to python2 and 3.4, neither of which support type hints~ now work again, I've updated the travis python version)